### PR TITLE
InvariantCulture to avoid syntax errors in CosmoDb query

### DIFF
--- a/docs/03_implement_vector_search_in_cosmos_db_nosql/0303.md
+++ b/docs/03_implement_vector_search_in_cosmos_db_nosql/0303.md
@@ -87,9 +87,11 @@ The key tasks are as follows:
 3. Provide a method named `ExecuteVectorSearch` in the `VectorizationService` for executing a vector search query against Azure Cosmos DB. The method should accept vectorized query text (called `queryVector`), the maximum number of results to return (named `max_results`), and the minimum similarity score (named `minimum_similarity_score`) and execute a query using the `VectorDistance()` function. It should return a list of `VectorSearchResult` objects. The count should limit the number of results returned. The query executed in Cosmos DB should use the following pattern:
 
     ```csharp
-    var query = $"SELECT c.hotel_id AS HotelId, c.hotel AS Hotel, c.details AS Details, c.source AS Source, VectorDistance(c.request_vector, [{string.Join(",", queryVector)}]) AS SimilarityScore FROM c";
-    query += $" WHERE VectorDistance(c.request_vector, [{string.Join(",", queryVector)}]) > {minimum_similarity_score}";
-    query += $" ORDER BY VectorDistance(c.request_vector, [{string.Join(",", queryVector)}])";
+    var vectorString = string.Join(", ", queryVector.Select(v => v.ToString(CultureInfo.InvariantCulture)).ToArray());
+
+    var query = $"SELECT c.hotel_id AS HotelId, c.hotel AS Hotel, c.details AS Details, c.source AS Source, VectorDistance(c.request_vector, [{vectorString}]) AS SimilarityScore FROM c";
+    query += $" WHERE VectorDistance(c.request_vector, [{vectorString}]) > {minimum_similarity_score.ToString(CultureInfo.InvariantCulture)}";
+    query += $" ORDER BY VectorDistance(c.request_vector, [{vectorString}])";
     ```
 
     <details markdown="block">


### PR DESCRIPTION
While running the API locally against the /VectorSearch, the OS regional settings influence the CosmoDb query string formatting unless InvariantCulture is used.
In a system with non-english regional settings, an exception like "Syntax error, incorrect syntax near ','." might be encountered as the decimal sign in the string query gets formatted as, for example, `WHERE VectorDistance(c.request_vector, ....) > 0,5` instead of `WHERE VectorDistance(c.request_vector, ....) > 0.5`