### PR TITLE
Update To support the DatabaseService now includes a creation parameter.

### DIFF
--- a/docs/02_implement_function_calls/02_02.md
+++ b/docs/02_implement_function_calls/02_02.md
@@ -89,7 +89,7 @@ public async Task<IEnumerable<Booking>> GetBookingsMissingHotelRooms()
                 );
             """;
         using var conn = new SqlConnection(
-            connectionString: Environment.GetEnvironmentVariable("SQLAZURECONNSTR_ContosoSuites")!
+            connectionString: connectionString!
         );
         conn.Open();
         using var cmd = new SqlCommand(sql, conn);
@@ -136,7 +136,7 @@ public async Task<IEnumerable<Booking>> GetBookingsWithMultipleHotelRooms()
                 ) > 1;
             """;
         using var conn = new SqlConnection(
-            connectionString: Environment.GetEnvironmentVariable("SQLAZURECONNSTR_ContosoSuites")!
+            connectionString: connectionString!
         );
         conn.Open();
         using var cmd = new SqlCommand(sql, conn);
@@ -264,7 +264,8 @@ builder.Services.AddSingleton<Kernel>((_) =>
         endpoint: builder.Configuration["AzureOpenAI:Endpoint"]!,
         apiKey: builder.Configuration["AzureOpenAI:ApiKey"]!
     );
-    kernelBuilder.Plugins.AddFromType<DatabaseService>();
+    var databaseService = _.GetRequiredService<IDatabaseService>();
+    kernelBuilder.Plugins.AddFromObject(databaseService);
     return kernelBuilder.Build();
 });
 ```

--- a/docs/02_implement_function_calls/02_02.md
+++ b/docs/02_implement_function_calls/02_02.md
@@ -323,7 +323,7 @@ app.MapPost("/Chat", async Task<string> (HttpRequest request) =>
 
 ### 09: Deploy to App Service
 
-Deploy your App Service code changes and ensure they propagate to Azure App Services. Then, add a three new environment variables to the App Service: `AzureOpenAI__DeploymentName`, `AzureOpenAI__Endpoint`, and `AzureOpenAI__ApiKey`. These environment variables should have **two** underscores between "AzureOpenAI" and the name.
+Deploy your App Service code changes and ensure they propagate to Azure App Services. Then, add a three new environment variables to the App Service: `AzureOpenAI__ApiKey`. This environment variables should have **two** underscores between "AzureOpenAI" and the name.
 
 {: .important }
 > In a production environment, it would be better to save these as secrets in Azure Key Vault and then enable a managed identity to access the Key Vault secrets from your App Service. The reason for this is, with the current configuration, anyone with access to manage the App Service can view the deployment name, endpoint, and API key secrets.
@@ -336,7 +336,7 @@ In order to create an environment variable for your App Service, perform the fol
 
     ![Creating a new environment variable for an Azure App Service](../../media/Solution/0202_AddEnvironmentVariable1.png)
 
-2. Create three environment variables. The first is `AzureOpenAI__DeploymentName` and should have a value of `gpt-4o`. The second is   `AzureOpenAI__Endpoint` and should have a value of your Azure OpenAI endpoint URL. The third is `AzureOpenAI__ApiKey` and should have a value of   your Azure OpenAI API key. After entering data for an application setting, select **Apply** to save the setting.
+2. Create the`AzureOpenAI__ApiKey` which should have a value of   your Azure OpenAI API key. After entering data for an application setting, select **Apply** to save the setting.
 
     ![Filling in details for the new environment variable for an Azure App Service](../../media/Solution/0202_AddEnvironmentVariable2.png)
 

--- a/src/ContosoSuitesDashboard/.streamlit/secrets.template.toml
+++ b/src/ContosoSuitesDashboard/.streamlit/secrets.template.toml
@@ -1,5 +1,6 @@
 [aoai]
 endpoint = "YOUR AZURE OPENAI ENDPOINT"
+key = "YOUR AZURE OPENAI KEY"
 deployment_name = "gpt-4o"
 embedding_deployment_name = "text-embedding-ada-002"
 


### PR DESCRIPTION
The update on 12/14/2024 of having the DatabaseService take a parameter means that the kernalBuilder can't register the plugin using AddFromType<>.   Changed to use the builder to grab the service and then add it to the Kernel using AddFromObject instead.