### PR TITLE
Update how cosmos is connected to the WebAPI

### DIFF
--- a/docs/03_implement_vector_search_in_cosmos_db_nosql/03_03.md
+++ b/docs/03_implement_vector_search_in_cosmos_db_nosql/03_03.md
@@ -39,7 +39,7 @@ In the previous task, you added vector embeddings to property maintenance reques
 
 ### 01: Add user secrets
 
-Add a new .NET user secret called `CosmosDB:ConnectionString`. This value should be your Cosmos DB connection string. Add another user secret called `AzureOpenAI:EmbeddingDeploymentName`, which should take on a value of `text-embedding-ada-002`.
+Add new .NET user secrets called `CosmosDB:AccountEndpoint` and `CosmosDB:ClientId`. These values should be your Cosmos DB URI and your Managed Identity Client ID. Add a third user secret called `AzureOpenAI:EmbeddingDeploymentName`, which should take on a value of `text-embedding-ada-002`.
 
 <details markdown="block">
 <summary><strong>Expand this section to view the solution</strong></summary>

--- a/docs/03_implement_vector_search_in_cosmos_db_nosql/03_03.md
+++ b/docs/03_implement_vector_search_in_cosmos_db_nosql/03_03.md
@@ -47,7 +47,8 @@ Add a new .NET user secret called `CosmosDB:ConnectionString`. This value should
 To add the user secrets, run the following command:
 
   ```sh
-  dotnet user-secrets set "CosmosDB:ConnectionString" "{YOUR_CONNECTION_STRING}"
+  dotnet user-secrets set "CosmosDB:AccountEndpoint" "{YOUR_COSMOSDB_URI}"
+  dotnet user-secrets set "CosmosDB:ClientId" "{YOUR_CLIENT_ID_FROM_RESOUREC_GROUP}"
   dotnet user-secrets set "CosmosDB:DatabaseName" "ContosoSuites"
   dotnet user-secrets set "CosmosDB:MaintenanceRequestsContainerName" "MaintenanceRequests"
   dotnet user-secrets set "AzureOpenAI:EmbeddingDeploymentName" "text-embedding-ada-002"

--- a/src/ContosoSuitesWebAPI/Program.cs
+++ b/src/ContosoSuitesWebAPI/Program.cs
@@ -31,8 +31,16 @@ builder.Services.AddSingleton<IDatabaseService, DatabaseService>((_) =>
 // Create a single instance of the CosmosClient to be shared across the application.
 builder.Services.AddSingleton<CosmosClient>((_) =>
 {
+
+    string userAssignedClientId = builder.Configuration["CosmosDB:ClientId"]!;
+    var credential = new DefaultAzureCredential(
+        new DefaultAzureCredentialOptions
+        {
+            ManagedIdentityClientId = userAssignedClientId
+        });
     CosmosClient client = new(
-        connectionString: builder.Configuration["CosmosDB:ConnectionString"]!
+        accountEndpoint: builder.Configuration["CosmosDB:AccountEndpoint"]!,
+        tokenCredential: credential
     );
     return client;
 });


### PR DESCRIPTION
Update to how Cosmos connects to Web API to not require Local Authentication to be active (which gets turned off by policy)