### PR TITLE
Moving to support Client_id based auth to Cosmos in Python

### DIFF
--- a/docs/01_deploy_app_resources/01_02.md
+++ b/docs/01_deploy_app_resources/01_02.md
@@ -128,6 +128,7 @@ Update the front-end code in `src/ContosoSuitesDashboard/` to enable chat operat
    6. For Cosmos DB secrets:
       1. Return to the resource group and select the Azure Cosmos DB account.
       2. In the **Settings** menu, navigate to the **Keys** option. Copy the value of **URI** and save it as `endpoint` in the `[cosmos]` section of your secrets file.
+      3. Find and copy the **ClientId** of the User-Assigned Managed Identity in your resource group. Paste it as the `client_id` value in the `[cosmos]` file
 
 2. Open the file `src/ContosoSuitesDashboard/pages/1_Chat_with_Data.py`. The code will run as-is, but will not have knowledge of your search index. To support chat with data, make the following changes to the Python script.
    1. Add the search secrets to the `create_chat_completion()` function, below the Azure OpenAI secrets and above the call to create a client.

--- a/docs/03_implement_vector_search_in_cosmos_db_nosql/03_03.md
+++ b/docs/03_implement_vector_search_in_cosmos_db_nosql/03_03.md
@@ -39,7 +39,7 @@ In the previous task, you added vector embeddings to property maintenance reques
 
 ### 01: Add user secrets
 
-Add new .NET user secrets called `CosmosDB:AccountEndpoint` and `CosmosDB:ClientId`. These values should be your Cosmos DB URI and your Managed Identity Client ID. Add a third user secret called `AzureOpenAI:EmbeddingDeploymentName`, which should take on a value of `text-embedding-ada-002`.
+Add new .NET user secrets called `CosmosDB__AccountEndpoint` and `AZURE_CLIENT_ID`. These values should be your Cosmos DB URI and your Managed Identity Client ID. Add a third user secret called `AzureOpenAI:EmbeddingDeploymentName`, which should take on a value of `text-embedding-ada-002`.
 
 <details markdown="block">
 <summary><strong>Expand this section to view the solution</strong></summary>
@@ -47,8 +47,8 @@ Add new .NET user secrets called `CosmosDB:AccountEndpoint` and `CosmosDB:Client
 To add the user secrets, run the following command:
 
   ```sh
-  dotnet user-secrets set "CosmosDB:AccountEndpoint" "{YOUR_COSMOSDB_URI}"
-  dotnet user-secrets set "CosmosDB:ClientId" "{YOUR_CLIENT_ID_FROM_RESOUREC_GROUP}"
+  dotnet user-secrets set "CosmosDB__AccountEndpoint" "{YOUR_COSMOSDB_URI}"
+  dotnet user-secrets set "AZURE_CLIENT_ID" "{YOUR_CLIENT_ID_FROM_RESOUREC_GROUP}"
   dotnet user-secrets set "CosmosDB:DatabaseName" "ContosoSuites"
   dotnet user-secrets set "CosmosDB:MaintenanceRequestsContainerName" "MaintenanceRequests"
   dotnet user-secrets set "AzureOpenAI:EmbeddingDeploymentName" "text-embedding-ada-002"

--- a/docs/03_implement_vector_search_in_cosmos_db_nosql/03_03.md
+++ b/docs/03_implement_vector_search_in_cosmos_db_nosql/03_03.md
@@ -47,7 +47,7 @@ Add new .NET user secrets called `CosmosDB__AccountEndpoint` and `AZURE_CLIENT_I
 To add the user secrets, run the following command:
 
   ```sh
-  dotnet user-secrets set "CosmosDB__AccountEndpoint" "{YOUR_COSMOSDB_URI}"
+  dotnet user-secrets set "CosmosDB:AccountEndpoint" "{YOUR_COSMOSDB_URI}"
   dotnet user-secrets set "AZURE_CLIENT_ID" "{YOUR_CLIENT_ID_FROM_RESOUREC_GROUP}"
   dotnet user-secrets set "CosmosDB:DatabaseName" "ContosoSuites"
   dotnet user-secrets set "CosmosDB:MaintenanceRequestsContainerName" "MaintenanceRequests"

--- a/docs/03_implement_vector_search_in_cosmos_db_nosql/03_03.md
+++ b/docs/03_implement_vector_search_in_cosmos_db_nosql/03_03.md
@@ -39,7 +39,7 @@ In the previous task, you added vector embeddings to property maintenance reques
 
 ### 01: Add user secrets
 
-Add new .NET user secrets called `CosmosDB__AccountEndpoint` and `AZURE_CLIENT_ID`. These values should be your Cosmos DB URI and your Managed Identity Client ID. Add a third user secret called `AzureOpenAI:EmbeddingDeploymentName`, which should take on a value of `text-embedding-ada-002`.
+Add new .NET user secrets called `CosmosDB:AccountEndpoint` and `AZURE_CLIENT_ID`. These values should be your Cosmos DB URI and your Managed Identity Client ID. Add a third user secret called `AzureOpenAI:EmbeddingDeploymentName`, which should take on a value of `text-embedding-ada-002`.
 
 <details markdown="block">
 <summary><strong>Expand this section to view the solution</strong></summary>

--- a/docs/04_implement_audio_transcription/04_03.md
+++ b/docs/04_implement_audio_transcription/04_03.md
@@ -129,15 +129,17 @@ def save_transcript_to_cosmos_db(transcript_item):
     """Save embeddings to Cosmos DB vector store. Key assumptions:
     - transcript_item is a JSON object containing call_id (int), 
         call_transcript (string), and request_vector (list).
-    - Cosmos DB endpoint, key, and database name stored in Streamlit secrets."""
+    - Cosmos DB endpoint, client_id, and database name stored in Streamlit secrets."""
+
+    cosmos_client_id = st.secrets["cosmos"]["client_id"]
+    cosmos_credentials = DefaultAzureCredential(managed_identity_client_id=cosmos_client_id)
 
     cosmos_endpoint = st.secrets["cosmos"]["endpoint"]
-    cosmos_key = st.secrets["cosmos"]["key"]
     cosmos_database_name = st.secrets["cosmos"]["database_name"]
     cosmos_container_name = "CallTranscripts"
 
     # Create a CosmosClient
-    client = CosmosClient(url=cosmos_endpoint, credential=cosmos_key)
+    client = CosmosClient(url=cosmos_endpoint, credential=cosmos_credentials)
     # Load the Cosmos database and container
     database = client.get_database_client(cosmos_database_name)
     container = database.get_container_client(cosmos_container_name)
@@ -195,10 +197,12 @@ The completed version of the `make_cosmos_db_vector_search_request()` function i
 def make_cosmos_db_vector_search_request(query_embedding, max_results=5,minimum_similarity_score=0.5):
     """Create and return a new vector search request. Key assumptions:
     - Query embedding is a list of floats based on a search string.
-    - Cosmos DB endpoint, key, and database name stored in Streamlit secrets."""
+    - Cosmos DB endpoint, client_id, and database name stored in Streamlit secrets."""
+
+    cosmos_client_id = st.secrets["cosmos"]["client_id"]
+    cosmos_credentials = DefaultAzureCredential(managed_identity_client_id=cosmos_client_id)
 
     cosmos_endpoint = st.secrets["cosmos"]["endpoint"]
-    cosmos_key = st.secrets["cosmos"]["key"]
     cosmos_database_name = st.secrets["cosmos"]["database_name"]
     cosmos_container_name = "CallTranscripts"
 
@@ -206,7 +210,7 @@ def make_cosmos_db_vector_search_request(query_embedding, max_results=5,minimum_
     client = CosmosClient(url=cosmos_endpoint, credential=cosmos_key)
     # Load the Cosmos database and container
     database = client.get_database_client(cosmos_database_name)
-    container = database.get_container_client(cosmos_container_name)
+    container = database.get_container_client(cosmos_credentials)
 
     results = container.query_items(
         query=f"""

--- a/src/ContosoSuitesDashboard/.streamlit/secrets.template.toml
+++ b/src/ContosoSuitesDashboard/.streamlit/secrets.template.toml
@@ -23,3 +23,4 @@ endpoint = "YOUR WEB API ENDPOINT"
 [cosmos]
 endpoint = "YOUR COSMOS DB ENDPOINT"
 database_name = "ContosoSuites"
+client_id = "YOUR MANAGED IDENTITY CLIENT ID"

--- a/src/ContosoSuitesDashboard/pages/4_Call_Center.py
+++ b/src/ContosoSuitesDashboard/pages/4_Call_Center.py
@@ -178,9 +178,10 @@ def save_transcript_to_cosmos_db(transcript_item):
     """Save embeddings to Cosmos DB vector store. Key assumptions:
     - transcript_item is a JSON object containing call_id (int), 
         call_transcript (string), and request_vector (list).
-    - Cosmos DB endpoint, key, and database name stored in Streamlit secrets."""
+    - Cosmos DB endpoint, client_id, and database name stored in Streamlit secrets."""
 
-    cosmos_credentials = DefaultAzureCredential()
+    cosmos_client_id = st.secrets["cosmos"]["client_id"]
+    cosmos_credentials = DefaultAzureCredential(managed_identity_client_id=cosmos_client_id)
 
     cosmos_endpoint = st.secrets["cosmos"]["endpoint"]
     cosmos_database_name = st.secrets["cosmos"]["database_name"]

--- a/src/ContosoSuitesDashboard/pages/5_Call_Center_Search.py
+++ b/src/ContosoSuitesDashboard/pages/5_Call_Center_Search.py
@@ -13,10 +13,12 @@ def make_azure_openai_embedding_request(text):
 def make_cosmos_db_vector_search_request(query_embedding, max_results=5, minimum_similarity_score=0.5):
     """Create and return a new vector search request. Key assumptions:
     - Query embedding is a list of floats based on a search string.
-    - Cosmos DB endpoint, key, and database name stored in Streamlit secrets."""
+    - Cosmos DB endpoint, client_id, and database name stored in Streamlit secrets."""
+
+    cosmos_client_id = st.secrets["cosmos"]["client_id"]
+    cosmos_credentials = DefaultAzureCredential(managed_identity_client_id=cosmos_client_id)
 
     cosmos_endpoint = st.secrets["cosmos"]["endpoint"]
-    cosmos_key = st.secrets["cosmos"]["key"]
     cosmos_database_name = st.secrets["cosmos"]["database_name"]
     cosmos_container_name = "CallTranscripts"
 

--- a/src/ContosoSuitesWebAPI/Program.cs
+++ b/src/ContosoSuitesWebAPI/Program.cs
@@ -32,7 +32,7 @@ builder.Services.AddSingleton<IDatabaseService, DatabaseService>((_) =>
 builder.Services.AddSingleton<CosmosClient>((_) =>
 {
 
-    string userAssignedClientId = builder.Configuration["CosmosDB:ClientId"]!;
+    string userAssignedClientId = builder.Configuration["AZURE_CLIENT_ID"]!;
     var credential = new DefaultAzureCredential(
         new DefaultAzureCredentialOptions
         {


### PR DESCRIPTION
Few typo fixes but mostly moving the Cosmos connections in the python code to use DefaultAzureCredential with the managed identity client id.