### PR TITLE
Change gpt-4o to GlobalStandard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,4 +350,4 @@ ASALocalRun/
 
 **/config_full.json
 
-*.local.json
+appsettings.*.json

--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,5 @@ ASALocalRun/
 .vscode/settings.json
 
 **/config_full.json
+
+*.local.json

--- a/docs/02_implement_function_calls/02_01.md
+++ b/docs/02_implement_function_calls/02_01.md
@@ -62,30 +62,25 @@ If you have a tool such as SQL Server Management Studio or Azure Data Studio alr
 
 ### 03: Create a local connection string
 
-Update the `ContosoSuites` connection string in your local `src/ContosoSuitesWebAPI/appsettings.json` file for your Azure SQL DB. Use Active Directory Default authentication.
+Create the `ContosoSuites` connection string in your local `src/ContosoSuitesWebAPI/appsettings.local.json` file for your Azure SQL DB. Use Active Directory Default authentication.
 
 <details markdown="block">
 <summary><strong>Expand this section to view the solution</strong></summary>
 
-1. Open your local `src/ContosoSuitesWebAPI/appsettings.json` file.
+1. Create a new  local `src/ContosoSuitesWebAPI/appsettings.local.json` file.
 2. Update the **{your server}** value inside the `ContosoSuites` connection string with your Azure SQL DB server name.
 
-The complete appsettings.json file should look like this:
+The complete appsettings.local.json file should look like this:
 
 ```json
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
-  "AllowedHosts": "*",
   "ConnectionStrings": {
     "ContosoSuites": "Server=tcp:{your server}.database.windows.net,1433;Initial Catalog=ContosoSuitesBookings;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;Authentication='Active Directory Default';"
   }
 }
 ```
+
+> Notice that we are not setting this vaule in the main `appsettings.json` file to avoid pushing secrets to your git repo.
 
 </details>
 

--- a/docs/02_implement_function_calls/02_01.md
+++ b/docs/02_implement_function_calls/02_01.md
@@ -62,15 +62,15 @@ If you have a tool such as SQL Server Management Studio or Azure Data Studio alr
 
 ### 03: Create a local connection string
 
-Create the `ContosoSuites` connection string in your local `src/ContosoSuitesWebAPI/appsettings.local.json` file for your Azure SQL DB. Use Active Directory Default authentication.
+Create the `ContosoSuites` connection string in your local `src/ContosoSuitesWebAPI/appsettings.Development.json` file for your Azure SQL DB. Use Active Directory Default authentication.
 
 <details markdown="block">
 <summary><strong>Expand this section to view the solution</strong></summary>
 
-1. Create a new  local `src/ContosoSuitesWebAPI/appsettings.local.json` file.
+1. Create a new  local `src/ContosoSuitesWebAPI/appsettings.Development.json` file.
 2. Update the **{your server}** value inside the `ContosoSuites` connection string with your Azure SQL DB server name.
 
-The complete appsettings.local.json file should look like this:
+The complete `appsettings.Development.json` file should look like this:
 
 ```json
 {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -66,7 +66,10 @@ var deployments = [
       name: 'gpt-4o'
       version: '2024-05-13'
     }
-    capacity: 40
+    sku: {
+      name: 'GlobalStandard'
+      capacity: 40
+    }
   }
   {
     name: 'text-embedding-ada-002'


### PR DESCRIPTION
This pull request includes a change to the `infra/main.bicep` file to update the deployment configuration for the `gpt-4o` model. The change adds a new SKU configuration to specify the name and capacity for the deployment.

Deployment configuration update:

* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R69-R73): Added `sku` configuration with `name` set to 'GlobalStandard' and `capacity` set to 40 for the `gpt-4o` deployment.

Fixes #54 