### PR TITLE
Fix path separators in tasks.json for consistency across platforms

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,7 @@
 		"type": "process",
 		"problemMatcher": "$msCompile",
 		"options": {
-		  "cwd": "${workspaceFolder}/src\\ContosoSuitesVectorizationFunction"
+		  "cwd": "${workspaceFolder}/src/ContosoSuitesVectorizationFunction"
 		}
 	  },
 	  {
@@ -31,7 +31,7 @@
 		},
 		"problemMatcher": "$msCompile",
 		"options": {
-		  "cwd": "${workspaceFolder}/src\\ContosoSuitesVectorizationFunction"
+		  "cwd": "${workspaceFolder}/src/ContosoSuitesVectorizationFunction"
 		}
 	  },
 	  {
@@ -47,7 +47,7 @@
 		"type": "process",
 		"problemMatcher": "$msCompile",
 		"options": {
-		  "cwd": "${workspaceFolder}/src\\ContosoSuitesVectorizationFunction"
+		  "cwd": "${workspaceFolder}/src/ContosoSuitesVectorizationFunction"
 		}
 	  },
 	  {
@@ -64,7 +64,7 @@
 		"dependsOn": "clean release (functions)",
 		"problemMatcher": "$msCompile",
 		"options": {
-		  "cwd": "${workspaceFolder}/src\\ContosoSuitesVectorizationFunction"
+		  "cwd": "${workspaceFolder}/src/ContosoSuitesVectorizationFunction"
 		}
 	  },
 	  {


### PR DESCRIPTION

This pull request includes changes to the `.vscode/tasks.json` file to standardize the path format for the `cwd` option. The changes replace backslashes with forward slashes in the paths.

Path format standardization:

* Standardized the `cwd` paths to use forward slashes instead of backslashes in multiple entries in the `.vscode/tasks.json` file. [[1]](diffhunk://#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745aL15-R15) [[2]](diffhunk://#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745aL34-R34) [[3]](diffhunk://#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745aL50-R50) [[4]](diffhunk://#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745aL67-R67)


Fixes #58
