### PR TITLE
Remove managed identity configuration from local.settings.json example

### DIFF
--- a/docs/03_implement_vector_search_in_cosmos_db_nosql/03_02.md
+++ b/docs/03_implement_vector_search_in_cosmos_db_nosql/03_02.md
@@ -114,8 +114,6 @@ To create a `local.settings.json` file, navigate to the `src\ContosoSuitesVector
     "AzureOpenAIEndpoint": "[YOUR_AZURE_OPENAI_ENDPOINT]",
     "AzureOpenAIKey": "[YOUR_AZURE_OPENAI_KEY]",
     "CosmosDBConnection__accountEndpoint": "[YOUR_COSMOS_DB_ENDPOINT]",
-    "CosmosDBConnection__clientId": "[USER_ASSIGNED_MANAGED_IDENTITY_CLIENT_ID]",
-    "CosmosDBConnection__credential": "managedidentity",
     "EmbeddingDeploymentName": "text-embedding-ada-002"
   }
 }


### PR DESCRIPTION
This pull request includes a small change to the `docs/03_implement_vector_search_in_cosmos_db_nosql/03_02.md` file. The change removes two configuration settings related to CosmosDB connection from the `local.settings.json` file.

Configuration updates:

* Removed `CosmosDBConnection__clientId` and `CosmosDBConnection__credential` settings from `local.settings.json` in `docs/03_implement_vector_search_in_cosmos_db_nosql/03_02.md`.

Fixes #57 