### PR TITLE
Add instructions for creating a leases container in Cosmos DB

### DIFF
--- a/docs/03_implement_vector_search_in_cosmos_db_nosql/03_01.md
+++ b/docs/03_implement_vector_search_in_cosmos_db_nosql/03_01.md
@@ -101,3 +101,23 @@ Container vector policies and vector indexing policies must be defined at the ti
 > If you receive an error message that "A Container Vector Policy has been provided, but the capability has not been enabled on your account," wait another 5-10 minutes before trying again.
 
   </details>
+
+### 03: Create leases container
+
+The Azure Function is going to use the [Change Feed Processor of CosmosDB](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/change-feed-functions) to get the new items and vectorize them. This feature needs a `leases` collection to synchronize the work, that is usually automatically created by using the `CreateLeaseContainerIfNotExists = true` attribute. But, you cannot use this when combined with a Managed Identity connection [*](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/troubleshoot-changefeed-functions#your-azure-function-fails-to-start-with-error-message-forbidden-403-substatus-5300-the-given-request-post--cant-be-authorized-by-microsoft-entra-token-in-data-plane). We need to manually create a collection called `leases` with partition key `/id`.
+
+<details markdown="block">
+<summary><strong>Expand this section to view the solution</strong></summary>
+
+In order to create a new container named `leases`, perform the following steps:
+
+1. In the [Azure portal](https://portal.azure.com), navigate to your Cosmos DB resource.
+2. Select **Data Explorer** in the left-hand menu.
+3. On the **Data Explorer** page, select **New Container**
+4. In the **New Container** dialog:
+   1. Select **Use existing** under **Database id** and select the **ContosoSuites** database from the dropdown list.
+   2. Enter "leases" into the **Container id** box.
+   3. Enter "/id" into the **Partition key** box. 
+   5. Select **OK** to create the container.
+
+</details>


### PR DESCRIPTION
This pull request includes a significant update to the documentation for implementing vector search in Cosmos DB NoSQL. The most important change introduces a new section on creating a leases container, which is necessary for the Azure Function to use the Change Feed Processor of CosmosDB.

Documentation update:

* [`docs/03_implement_vector_search_in_cosmos_db_nosql/03_01.md`](diffhunk://#diff-1e89620c80567d7885cce49b9646890d33066fba208453c835108bfc18b5b8c4R104-R123): Added a detailed section on creating a leases container for the Change Feed Processor, including step-by-step instructions and a link to the relevant Azure documentation.

Fixes #56 