### PR TITLE
Update audio transcription documentation with Azure credential import and fix CosmosClient

### DIFF
--- a/docs/04_implement_audio_transcription/04_03.md
+++ b/docs/04_implement_audio_transcription/04_03.md
@@ -87,6 +87,12 @@ def make_azure_openai_embedding_request(text):
     )
 ```
 
+If the code shows some errors on the `DefaultAzureCredential` or `get_bearer_token_provider` you may need to add this line at the top of the file:
+
+```python
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+```
+
 </details>
 
 ### 03: Generate embeddings
@@ -207,10 +213,10 @@ def make_cosmos_db_vector_search_request(query_embedding, max_results=5,minimum_
     cosmos_container_name = "CallTranscripts"
 
     # Create a CosmosClient
-    client = CosmosClient(url=cosmos_endpoint, credential=cosmos_key)
+    client = CosmosClient(url=cosmos_endpoint, credential=cosmos_credentials)
     # Load the Cosmos database and container
     database = client.get_database_client(cosmos_database_name)
-    container = database.get_container_client(cosmos_credentials)
+    container = database.get_container_client(cosmos_container_name)
 
     results = container.query_items(
         query=f"""


### PR DESCRIPTION
This pull request includes updates to the documentation for implementing audio transcription. The changes focus on fixing code errors and improving clarity.

Documentation updates:

* [`docs/04_implement_audio_transcription/04_03.md`](diffhunk://#diff-92f84df84d7eb350f562ce695789e494c777b78ab0addab3c9cdfd5279cb937cR90-R95): Added an import statement for `DefaultAzureCredential` and `get_bearer_token_provider` to prevent potential errors.
* [`docs/04_implement_audio_transcription/04_03.md`](diffhunk://#diff-92f84df84d7eb350f562ce695789e494c777b78ab0addab3c9cdfd5279cb937cL210-R219): Corrected the variable names in the `CosmosClient` initialization and container client retrieval to use `cosmos_credentials` and `cosmos_container_name` respectively.

Fixes #63 